### PR TITLE
Fixed iOS duplicate logging data

### DIFF
--- a/ios/Classes/LogHelper.swift
+++ b/ios/Classes/LogHelper.swift
@@ -210,7 +210,7 @@ class LogHelper: NSObject {
                 print("Adding to Zip: \(item)")
                 sourceURL = sourceURL.appendingPathComponent("/\(item)")
                 
-                try archive.addEntry(with: sourceURL.lastPathComponent, relativeTo: sourceURL.deletingLastPathComponent())
+                try archive.addEntry(with: sourceURL.lastPathComponent, relativeTo: sourceURL.deletingLastPathComponent(), compressionMethod: CompressionMethod.deflate)
                 
                 guard Archive(url: destinationURL, accessMode: .update) != nil else  {
                     print("Unable to update the Archive!")

--- a/ios/Classes/Logger.swift
+++ b/ios/Classes/Logger.swift
@@ -114,7 +114,9 @@ public class Logger {
     }
     
     public func addOutput(_ output: Output) {
+        if (!outputs.contains(where: {type(of: $0) == type(of: output)})) {
         outputs.append(output)
+        }
     }
     
     public func log(_ string: String) {


### PR DESCRIPTION
Logging data would double with every new log data because LogHelper.logThis is always calling Logger.addOutput function which would add multiple same Outputs.